### PR TITLE
OSW-2316: Transition to PyModbus 4.0

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,7 +17,7 @@ test:
     - ts-conda-build ==0.5
     - ts-xml
     - ts-salobj {{ salobj_version }}
-    - pymodbus ==3.11.4
+    - pymodbus >=3.13.0
   source_files:
     - python
     - bin
@@ -43,4 +43,4 @@ requirements:
     - setuptools_scm
     - ts-xml
     - ts-salobj {{ salobj_version }}
-    - pymodbus ==3.11.4
+    - pymodbus >=3.13.0

--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -4,6 +4,11 @@
 Version History
 ===============
 
+v1.5.11
+-------
+
+* Uses PyModbus 4.0 SimData/SimDevice.
+
 v1.5.10
 -------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [ "Programming Language :: Python :: 3" ]
 urls = { documentation = "https://ts-mtaircompressor.lsst.io", repository = "https://github.com/lsst-ts/ts_mtaircompressor" }
 dynamic = [ "version" ]
 dependencies = [
-  "pymodbus==3.11.4",
+  "pymodbus>=3.13.0",
   "pyserial-asyncio",
 ]
 

--- a/python/lsst/ts/mtaircompressor/simulator.py
+++ b/python/lsst/ts/mtaircompressor/simulator.py
@@ -24,27 +24,10 @@ __all__ = ["create_server", "create_server_and_run_on_background"]
 import asyncio
 import socket
 
-from pymodbus.datastore import (
-    ModbusDeviceContext,
-    ModbusSequentialDataBlock,
-    ModbusServerContext,
-)
 from pymodbus.server import ModbusTcpServer
+from pymodbus.simulator import DataType, SimData, SimDevice
 
 from .aircompressor_model import Register
-
-
-class SimulatedHrBlock(ModbusSequentialDataBlock):
-    def __init__(self) -> None:
-        block = [0] * 0x1E + list(range(1, 20)) + [0x01, 0x0, 0x01] + [0] * 0x120
-        super().__init__(0, block)
-
-    def setValues(self, address: int, values: list[int]) -> None:
-        # there is mismatch in indexing, + 1 is needed on Register.xxx side
-        if address == Register.REMOTE_CMD + 1:
-            super().setValues(Register.STATUS + 1, [0x02] if values[0] == 0xFF01 else [0x01])
-            super().setValues(Register.INHIBIT + 1, [0x00] if values[0] == 0xFF01 else [0x01])
-        super().setValues(address, values)
 
 
 def create_server() -> ModbusTcpServer:
@@ -56,10 +39,57 @@ def create_server() -> ModbusTcpServer:
     server : `ModbusTcpServer`
         Created server instance.
     """
-    store = ModbusDeviceContext(hr=SimulatedHrBlock())
-    context = ModbusServerContext(devices=store, single=True)
+    # 1. Define the initial data block using SimData
+    sim_data = [
+        SimData(address=Register.WATER_LEVEL, values=list(range(2, 20)), datatype=DataType.REGISTERS),
+        SimData(address=Register.STATUS, values=[0x01, 0x00, 0x01], datatype=DataType.REGISTERS),
+        SimData(address=Register.ERROR_E400, values=list(range(100, 116)), datatype=DataType.REGISTERS),
+        SimData(
+            address=Register.SOFTWARE_VERSION,
+            values="LSST Test Compressor 42",
+            count=2,
+            datatype=DataType.STRING,
+        ),
+        SimData(address=Register.SERIAL_NUMER, values="v0.0.0", count=2, datatype=DataType.STRING),
+        SimData(address=Register.REMOTE_CMD, values=0, count=1, datatype=DataType.REGISTERS),
+        SimData(address=Register.RESET, values=0, count=1, datatype=DataType.REGISTERS),
+    ]
 
-    return ModbusTcpServer(context)
+    # We need a reference to the server inside the callback to update secondary
+    # registers.  A mutable list allows us to inject the server instance after
+    # it is instantiated.
+    server_ref: list[ModbusTcpServer] = []
+
+    # 2. Use the SimDevice `action` callback to intercept writes
+    async def intercept_remote_cmd(
+        device_id: int,
+        func_code: int,
+        address: int,
+        count: int,
+        old_values: list[int],
+        new_values: list[int] | list[bool] | None,
+    ) -> None:
+        # new_values is only populated on write requests.
+        if new_values is not None and address == Register.REMOTE_CMD:
+            val = new_values[0]
+            status_val = [0x02] if val == 0xFF01 else [0x01]
+            inhibit_val = [0x00] if val == 0xFF01 else [0x01]
+
+            if server_ref:
+                srv = server_ref[0]
+                # Update the side-effect registers.
+                # Function code 3 is typically used to represent holding
+                # registers internally.
+                await srv.async_setValues(device_id, 3, Register.STATUS, status_val)
+                await srv.async_setValues(device_id, 3, Register.INHIBIT, inhibit_val)
+
+    sim_device = SimDevice(id=0, simdata=sim_data, action=intercept_remote_cmd)
+
+    # 4. ModbusTcpServer can now take a SimDevice directly as its context
+    server = ModbusTcpServer(context=sim_device)
+    server_ref.append(server)
+
+    return server
 
 
 async def create_server_and_run_on_background() -> tuple[
@@ -84,7 +114,7 @@ async def create_server_and_run_on_background() -> tuple[
     server = create_server()
 
     # make sure socket is created and listen for incoming connection, so we can
-    # get it address
+    # get its address
     await server.listen()
 
     simulator_task = asyncio.create_task(server.serve_forever())
@@ -94,7 +124,7 @@ async def create_server_and_run_on_background() -> tuple[
         raise RuntimeError(
             "The simulator cannot get data of any connected socket. Most likely "
             "the previous tests failed, leaving simulator server listening for "
-            "the incoming connectons."
+            "the incoming connections."
         )
     host, port = socket.getnameinfo(st.getsockname(), socket.NI_NUMERICSERV)
     return server, simulator_task, host, int(port)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -40,3 +40,33 @@ class MTAirCompressorModelTestCase(unittest.IsolatedAsyncioTestCase):
         model = mtaircompressor.MTAirCompressorModel(self.client, 1)
         analog_data = await model.get_analog_data()
         assert analog_data[0:10] == [2, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+
+    async def test_utils(self) -> None:
+        model = mtaircompressor.MTAirCompressorModel(self.client, 1)
+        # simulated string is "LSST Test Compressor 42", but somehow isn't
+        # working right in PyModbus yet
+        assert await model.get_compressor_info() == [
+            0x4C53,
+            0x5354,
+            0x2054,
+            0x6573,
+            0x7420,
+            0x436F,
+            0x6D70,
+            0x7265,
+            0x7373,
+            0x6F72,
+            0x2034,
+            0x3200,
+            0x4C53,
+            0x5354,
+            0x2054,
+            0x6573,
+            0x7420,
+            0x436F,
+            0x6D70,
+            0x7265,
+            0x7373,
+            0x6F72,
+            0x2034,
+        ]


### PR DESCRIPTION
PyModbus >= 3.13.0 version contains simulator changes for PyModbus 4.0 API: 

https://pymodbus.readthedocs.io/en/latest/source/upgrade_40.html